### PR TITLE
FirebaseGuard.php updated to use the Laravel Guard interface correctly.

### DIFF
--- a/src/FirebaseGuard.php
+++ b/src/FirebaseGuard.php
@@ -2,57 +2,102 @@
 
 namespace Firevel\FirebaseAuthentication;
 
+use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Http\Request;
 use Kreait\Firebase\JWT\IdTokenVerifier;
 
-class FirebaseGuard
+class FirebaseGuard implements Guard
 {
-    /**
-     * @var Kreait\Firebase\JWT\IdTokenVerifier
-     */
-    protected $verifier;
+	/**
+	 * @var Kreait\Firebase\JWT\IdTokenVerifier
+	 */
+	protected $verifier;
+	protected $user;
+	protected $request;
 
-    /**
-     * Constructor.
-     *
-     * @return void
-     */
-    public function __construct(IdTokenVerifier $verifier)
-    {
-        $this->verifier = $verifier;
-    }
+	/**
+	 * Constructor.
+	 *
+	 * @return void
+	 */
+	public function __construct(IdTokenVerifier $verifier, ?Request $request = null)
+	{
+		$this->verifier = $verifier;
+		$this->request = $request ?: request();
+	}
 
-    /**
-     * Get User by request claims.
-     *
-     * @return mixed|null
-     */
-    public function user(Request $request)
-    {
-        $token = $request->bearerToken();
+	/**
+	 * Get User by request claims.
+	 *
+	 * @return mixed|null
+	 */
+	public function user()
+	{
+		if ($this->user) {
+			return $this->user;
+		}
 
-        if (empty($token)) {
-            return;
-        }
+		$token = $this->request->bearerToken();
+		if (empty($token)) {
+			return;
+		}
 
-        try {
-            $firebaseToken = $this->verifier->verifyIdToken($token);
+		try {
+			$firebaseToken = $this->verifier->verifyIdToken($token);
 
-            return app(config('auth.providers.users.model'))
-                ->resolveByClaims($firebaseToken->payload())
-                ->setFirebaseAuthenticationToken($token);
-        } catch (\Exception $e) {
-            if ($e instanceof \Kreait\Firebase\JWT\Error\IdTokenVerificationFailed) {
-                if (str_contains($e->getMessage(), 'token is expired')) {
-                    return;
-                }
-            }
+			$user = app(config('auth.providers.users.model'))
+				->resolveByClaims($firebaseToken->payload());
 
-            if (config('app.debug')) {
-                throw $e;
-            }
+			if ($user) {
+				$user->setFirebaseAuthenticationToken($token);
+			}
 
-            return;
-        }
-    }
+			return $this->user = $user;
+		} catch (\Exception $e) {
+			if ($e instanceof \Kreait\Firebase\JWT\Error\IdTokenVerificationFailed) {
+				if (str_contains($e->getMessage(), 'token is expired')) {
+					return;
+				}
+			}
+
+			if (config('app.debug')) {
+				throw $e;
+			}
+
+			return;
+		}
+	}
+
+	public function validate(array $credentials = [])
+	{
+		// not used - Laravels sessionless guards skip this
+		return (bool) $this->user();
+	}
+
+	public function id()
+	{
+		return $this->user()?->getAuthIdentifier();
+	}
+
+	public function check()
+	{
+		return !is_null($this->user());
+	}
+
+	public function guest()
+	{
+		return is_null($this->user());
+	}
+
+	public function setUser(Authenticatable $user)
+	{
+		$this->user = $user;
+		return $this;
+	}
+
+	public function hasUser()
+	{
+		return !is_null($this->user);
+	}
 }


### PR DESCRIPTION
I've had a few issues while attempting to use this, so I've made some small changes to bring it inline with what Laravel is expecting a Guard to be. Please let me know if you have any questions.

- Note: I'm unsure if these changes are Laravel 12 specific, but I am using 12 and these changes are working brilliantly for me.

### Summary

**1) Converts FirebaseGuard into a full Illuminate\Contracts\Auth\Guard implementation.**

The original FirebaseGuard wasn’t registered with Laravel’s Auth system. It was just a plain helper class, not a real “guard” — so when something called: `$user = Auth::guard('api')->user();` Laravel’s AuthManager didn’t know about Firevel’s guard at all. It was using the default null driver — which always returns null.

This change ensures the FirebaseGuard is binded to the \Auth object. Syntax like `\Auth::id();` and `$user = Auth::user();` can now be used project wide, or the original firebase class can be used directly still for legacy use _(I'm assuming this is what people were doing to fetch the user before this change?)_:
```
$firebaseGuard = app(FirebaseGuard::class);
$user = $firebaseGuard->user($request);
```

Which means you can now set authorised only routes with middleare(['auth:api']), or create your own middleware which can simply attempt to fetch the user and implement your own logic _(such as not return unauthorised when no user for an optional route)_.


**2) Fixes user(Request $request) signature mismatch with Laravel’s expected user() & Adds missing methods (check, guest, id, hasUser, validate, setUser).**

These are only required to satisfy the Guard interface and work exactly as expected. No functionality change here.

**3) Maintains backward compatibility for direct $firebaseGuard->user() calls.**

This should ensure people updating shouldn't experience any issues.